### PR TITLE
Chore: Improve TokenBucket rate limiter with thread-safety, precision, and logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	limiter := ratelimiter.NewTokenBucket(10, 1) // Max 10 tokens, 1 token per second
+	limiter := ratelimiter.NewTokenBucket(10, 1, true) // Max 10 tokens, 1 token per second, enable logging
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if !limiter.Allow() {


### PR DESCRIPTION
- Added sync.Mutex to ensure thread-safety for concurrent requests
- Refined token refill mechanism using float64 for higher precision
- Added optional logging to provide insights on request handling
- Updated main.go to support new logging option in the TokenBucket constructor

#Hacktoberfest